### PR TITLE
fix some issues

### DIFF
--- a/style.css
+++ b/style.css
@@ -848,7 +848,7 @@ div.wpcf7-mail-sent-ok {
 	font-weight: normal;
 	font-size: 76px;
 	color: #231f20;
-	line-height: 60px;
+	line-height: 72px;
 }
 
 footer.entry-footer {
@@ -2945,6 +2945,7 @@ body.page-template-page_widgetized {
 	text-align: center;
 	background: url(images/head-texture.jpg) repeat 0 0;
 	padding-bottom: 160px;
+	max-height: 100vh;
 }
 
 .header-image::after {
@@ -2971,7 +2972,6 @@ body.page-template-page_widgetized {
 	color: #000;
 	font-size: 50px;
 	display: block;
-	padding-right: 47%;
 	text-transform: unset;
 	font-family: 'HelveticaNeueLTStd-BdCn';
 	letter-spacing: 0px!important;
@@ -4627,7 +4627,7 @@ body.page-template-page_widgetized {
 	}
 	.header-subtext span {
 		font-size: 66px;
-		line-height: 25px;
+		line-height: 64px;
 	}
 	.header-subtext br {
 		content: "";
@@ -4994,7 +4994,7 @@ body.page-template-page_widgetized {
 	}
 	.header-subtext span {
 		font-size: 46px;
-		line-height: 6px;
+		line-height: 50px;
 	}
 	.vc_column-inner.vc_custom_1515136445464 h2 {
 		font-size: 29px!important;
@@ -5047,7 +5047,7 @@ body.page-template-page_widgetized {
 		font-weight: normal;
 		font-size: 76px!important;
 		color: #231f20;
-		line-height: 50px;
+		line-height: 74px;
 	}
 }
 


### PR DESCRIPTION
- [x] Put each word of "Applied Nonprofit Research" on its own line
- [x] Do the above in such a way that the text does not overlap the image on the right at any screen resolution (desktop, tablet, or phone, in any orientation).
- [x] Adjust the font size of the byline ("Deep data on the nonprofit sector") to look good with the longer, heavier text now displayed above.